### PR TITLE
Replace LU by Bunch-Kaufman

### DIFF
--- a/src/KrigingEstimators.jl
+++ b/src/KrigingEstimators.jl
@@ -8,7 +8,7 @@ using GeoStatsBase
 using Variography
 
 using LinearAlgebra: Factorization, Symmetric
-using LinearAlgebra: lu, cholesky, issuccess, ⋅
+using LinearAlgebra: bunchkaufman, cholesky, issuccess, ⋅
 using Distances: Euclidean
 using Distributions: Normal
 using Combinatorics: multiexponents

--- a/src/estimators/external_drift_kriging.jl
+++ b/src/estimators/external_drift_kriging.jl
@@ -49,7 +49,7 @@ function set_constraints_lhs!(estimator::ExternalDriftKriging, LHS::AbstractMatr
   nothing
 end
 
-factorize(estimator::ExternalDriftKriging, LHS::AbstractMatrix) = lu(Symmetric(LHS), check=false)
+factorize(estimator::ExternalDriftKriging, LHS::AbstractMatrix) = bunchkaufman(Symmetric(LHS), check=false)
 
 function set_constraints_rhs!(estimator::FittedKriging{E,S},
                               xₒ::AbstractVector) where {E<:ExternalDriftKriging,S<:KrigingState}

--- a/src/estimators/ordinary_kriging.jl
+++ b/src/estimators/ordinary_kriging.jl
@@ -30,7 +30,7 @@ function set_constraints_lhs!(estimator::OrdinaryKriging, LHS::AbstractMatrix, X
   nothing
 end
 
-factorize(estimator::OrdinaryKriging, LHS::AbstractMatrix) = lu(Symmetric(LHS), check=false)
+factorize(estimator::OrdinaryKriging, LHS::AbstractMatrix) = bunchkaufman(Symmetric(LHS), check=false)
 
 function set_constraints_rhs!(estimator::FittedKriging{E,S},
                               xₒ::AbstractVector) where {E<:OrdinaryKriging,S<:KrigingState}

--- a/src/estimators/universal_kriging.jl
+++ b/src/estimators/universal_kriging.jl
@@ -66,7 +66,7 @@ function set_constraints_lhs!(estimator::UniversalKriging, LHS::AbstractMatrix, 
   nothing
 end
 
-factorize(estimator::UniversalKriging, LHS::AbstractMatrix) = lu(Symmetric(LHS), check=false)
+factorize(estimator::UniversalKriging, LHS::AbstractMatrix) = bunchkaufman(Symmetric(LHS), check=false)
 
 function set_constraints_rhs!(estimator::FittedKriging{E,S},
                               xₒ::AbstractVector) where {E<:UniversalKriging,S<:KrigingState}


### PR DESCRIPTION
This PR replaces LU by Bunch-Kaufman (LDL'). I am sorry for the misunderstanding @exepulveda , I didn't know of this alternative name for the factorization. Could you please review and approve this PR before we merge?

Fix https://github.com/JuliaEarth/GeoStats.jl/issues/97