### PR TITLE
Fixing using NearestNeighborSearcher instead KNearestSearcher

### DIFF
--- a/src/solvers/kriging.jl
+++ b/src/solvers/kriging.jl
@@ -112,7 +112,7 @@ function preprocess(problem::EstimationProblem, solver::Kriging)
         else
           # nearest neighbor search with a distance
           distance = varparams.distance
-          bsearcher = NearestNeighborSearcher(pdata, maxneighbors, metric=distance)
+          bsearcher = KNearestSearcher(pdata, maxneighbors, metric=distance)
         end
       else
         # use all data points as neighbors


### PR DESCRIPTION
It seems after the refactoring NearestNeighborSearcher was not replaced by KNearestSearcher.

I wonder why the tests did not pick this up.